### PR TITLE
Remove terraform-provider-template dependency

### DIFF
--- a/modules/eks-node-group/README.md
+++ b/modules/eks-node-group/README.md
@@ -17,8 +17,7 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.5.0 |
 
 ## Modules
 
@@ -33,7 +32,6 @@ This module creates following resources.
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
-| [template_file.userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/modules/eks-node-group/main.tf
+++ b/modules/eks-node-group/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "this" {
 
   ebs_optimized = var.ebs_optimized
 
-  user_data = base64encode(data.template_file.userdata.rendered)
+  user_data = base64encode(local.userdata)
 
   instance_initiated_shutdown_behavior = "terminate"
 

--- a/modules/eks-node-group/userdata.tf
+++ b/modules/eks-node-group/userdata.tf
@@ -24,14 +24,9 @@ locals {
     ],
     var.kubelet_extra_args,
   ))
-}
-
-data "template_file" "userdata" {
-  template = file("${path.module}/templates/userdata.sh.tpl")
-
-  vars = {
+  userdata = templatefile("${path.module}/templates/userdata.sh.tpl", {
     cluster_name         = var.cluster_name,
     bootstrap_extra_args = join(" ", local.bootstrap_extra_args),
     kubelet_extra_args   = join(" ", local.kubelet_extra_args)
-  }
+  })
 }


### PR DESCRIPTION
### Background

- Remove terraform-provider-template dependency to support M1 ARM arch.