### PR TITLE
Use override_policy_documents instead of override_json in ecr-registry module

### DIFF
--- a/modules/ecr-registry/main.tf
+++ b/modules/ecr-registry/main.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "this" {
     try(data.aws_iam_policy_document.pull_through_cache[*].json, []),
   )
 
-  override_json = var.policy
+  override_policy_documents = var.policy != null ? [var.policy] : null
 }
 
 resource "aws_ecr_registry_policy" "this" {


### PR DESCRIPTION
### Background

- `override_json` property for `aws_iam_policy_document` data source.