### PR TITLE
Update ecr-repository module

### DIFF
--- a/modules/ecr-repository/README.md
+++ b/modules/ecr-repository/README.md
@@ -18,7 +18,7 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
 
 ## Modules
 
@@ -38,11 +38,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | (Required) Desired name for the repository. | `string` | n/a | yes |
-| <a name="input_encryption_enabled"></a> [encryption\_enabled](#input\_encryption\_enabled) | (Optional) Enable Encryption for repository. | `bool` | `false` | no |
 | <a name="input_encryption_kms_key"></a> [encryption\_kms\_key](#input\_encryption\_kms\_key) | (Optional) The ARN of the KMS key to use when encryption\_type is `KMS`. If not specified, uses the default AWS managed key for ECR. | `string` | `null` | no |
 | <a name="input_encryption_type"></a> [encryption\_type](#input\_encryption\_type) | (Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`. | `string` | `"AES256"` | no |
-| <a name="input_image_scan_on_push_enabled"></a> [image\_scan\_on\_push\_enabled](#input\_image\_scan\_on\_push\_enabled) | (Optional) Indicates whether images are scanned after being pushed to the repository or not scanned. | `bool` | `false` | no |
-| <a name="input_image_tag_immutable_enabled"></a> [image\_tag\_immutable\_enabled](#input\_image\_tag\_immutable\_enabled) | (Optional) Should be true if you want to disable to modify image tags. | `bool` | `false` | no |
+| <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | (Optional) If `true`, will delete the repository even if it contains images. Defaults to `false`. | `bool` | `false` | no |
+| <a name="input_image_scan_on_push_enabled"></a> [image\_scan\_on\_push\_enabled](#input\_image\_scan\_on\_push\_enabled) | (Optional, Deprecated) Indicates whether images are scanned after being pushed to the repository or not scanned. | `bool` | `false` | no |
+| <a name="input_image_tag_immutable_enabled"></a> [image\_tag\_immutable\_enabled](#input\_image\_tag\_immutable\_enabled) | (Optional) Enable tag immutability to prevent image tags from being overwritten by subsequent image pushes using the same tag. Disable tag immutability to allow image tags to be overwritten. | `bool` | `false` | no |
 | <a name="input_lifecycle_rules"></a> [lifecycle\_rules](#input\_lifecycle\_rules) | (Optional) A list of ECR Repository Lifecycle rules. `priority` must be unique and do not need to be sequential across rules. `descriptoin` is optional. `type` is one of `tagged`, `untagged`, or `any`. `tag_prefixes` is required if you specified `tagged` type. Specify one of `expiration_days` or `expiration_count` | `any` | `[]` | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_repository_policy"></a> [repository\_policy](#input\_repository\_policy) | (Optional) The policy document for ECR Repository. This is a JSON formatted string. | `string` | `""` | no |
@@ -56,6 +56,9 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the repository. |
+| <a name="output_encryption"></a> [encryption](#output\_encryption) | The configuration for the encryption of repository. |
+| <a name="output_image_scan_on_push_enabled"></a> [image\_scan\_on\_push\_enabled](#output\_image\_scan\_on\_push\_enabled) | Whether to scan image on push. |
+| <a name="output_image_tag_immutable_enabled"></a> [image\_tag\_immutable\_enabled](#output\_image\_tag\_immutable\_enabled) | Whether to enable tag immutability to prevent image tags from being overwritten. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the repository. |
 | <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | The registry ID where the repository was created. |
 | <a name="output_url"></a> [url](#output\_url) | The URL of the repository (in the form aws\_account\_id.dkr.ecr.region.amazonaws.com/repositoryName). |

--- a/modules/ecr-repository/main.tf
+++ b/modules/ecr-repository/main.tf
@@ -17,19 +17,16 @@ locals {
 resource "aws_ecr_repository" "this" {
   name = local.metadata.name
 
+  force_delete         = var.force_delete
   image_tag_mutability = var.image_tag_immutable_enabled ? "IMMUTABLE" : "MUTABLE"
 
   image_scanning_configuration {
     scan_on_push = var.image_scan_on_push_enabled
   }
 
-  dynamic "encryption_configuration" {
-    for_each = var.encryption_enabled ? ["go"] : []
-
-    content {
-      encryption_type = var.encryption_type
-      kms_key         = var.encryption_kms_key
-    }
+  encryption_configuration {
+    encryption_type = var.encryption_type
+    kms_key         = var.encryption_kms_key
   }
 
   tags = merge(

--- a/modules/ecr-repository/outputs.tf
+++ b/modules/ecr-repository/outputs.tf
@@ -17,3 +17,21 @@ output "url" {
   description = "The URL of the repository (in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName)."
   value       = aws_ecr_repository.this.repository_url
 }
+
+output "image_tag_immutable_enabled" {
+  description = "Whether to enable tag immutability to prevent image tags from being overwritten."
+  value       = aws_ecr_repository.this.image_tag_mutability == "IMMUTABLE"
+}
+
+output "image_scan_on_push_enabled" {
+  description = "Whether to scan image on push."
+  value       = aws_ecr_repository.this.image_scanning_configuration[0].scan_on_push
+}
+
+output "encryption" {
+  description = "The configuration for the encryption of repository."
+  value = {
+    type    = aws_ecr_repository.this.encryption_configuration[0].encryption_type
+    kms_key = aws_ecr_repository.this.encryption_configuration[0].kms_key
+  }
+}

--- a/modules/ecr-repository/variables.tf
+++ b/modules/ecr-repository/variables.tf
@@ -4,27 +4,36 @@ variable "name" {
 }
 
 variable "image_tag_immutable_enabled" {
-  description = "(Optional) Should be true if you want to disable to modify image tags."
+  description = "(Optional) Enable tag immutability to prevent image tags from being overwritten by subsequent image pushes using the same tag. Disable tag immutability to allow image tags to be overwritten."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "image_scan_on_push_enabled" {
-  description = "(Optional) Indicates whether images are scanned after being pushed to the repository or not scanned."
+  description = "(Optional, Deprecated) Indicates whether images are scanned after being pushed to the repository or not scanned."
   type        = bool
   default     = false
+  nullable    = false
 }
 
-variable "encryption_enabled" {
-  description = "(Optional) Enable Encryption for repository."
+variable "force_delete" {
+  description = "(Optional) If `true`, will delete the repository even if it contains images. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "encryption_type" {
   description = "(Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`."
   type        = string
   default     = "AES256"
+  nullable    = false
+
+  validation {
+    condition     = contains(["AES256", "KMS"], var.encryption_type)
+    error_message = "Valid values are `AES256`, `KMS`."
+  }
 }
 
 variable "encryption_kms_key" {
@@ -37,12 +46,14 @@ variable "repository_policy" {
   description = "(Optional) The policy document for ECR Repository. This is a JSON formatted string."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "lifecycle_rules" {
   description = "(Optional) A list of ECR Repository Lifecycle rules. `priority` must be unique and do not need to be sequential across rules. `descriptoin` is optional. `type` is one of `tagged`, `untagged`, or `any`. `tag_prefixes` is required if you specified `tagged` type. Specify one of `expiration_days` or `expiration_count`"
   type        = any
   default     = []
+  nullable    = false
 }
 
 variable "tags" {


### PR DESCRIPTION
### Background

- New argument for `ecr-repository` module: `force_delete`
- Remove unnecessary argument for `ecr-repository` module: `encryption_enabled`
  - ECR Private repository is always enabled the encryption with `AES256` default type.
- Enhance outputs for `ecr-repository` module