### PR TITLE
Fix deprecated asg tags to tag block

### DIFF
--- a/modules/eks-node-group/README.md
+++ b/modules/eks-node-group/README.md
@@ -10,14 +10,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.45 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
 
 ## Modules
 
@@ -32,6 +32,7 @@ This module creates following resources.
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 
 ## Inputs
 

--- a/modules/eks-node-group/main.tf
+++ b/modules/eks-node-group/main.tf
@@ -31,14 +31,6 @@ locals {
     local.tags,
     local.default_tags,
   )
-  indirect_managed_asg_tags = [
-    for key, value in local.indirect_managed_tags : {
-      key   = key
-      value = value
-
-      propagate_at_launch = true
-    }
-  ]
 }
 
 
@@ -129,7 +121,16 @@ resource "aws_autoscaling_group" "this" {
     triggers = []
   }
 
-  tags = local.indirect_managed_asg_tags
+  dynamic "tag" {
+    for_each = local.indirect_managed_tags
+
+    content {
+      key   = tag.key
+      value = tag.value
+
+      propagate_at_launch = true
+    }
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/modules/eks-node-group/versions.tf
+++ b/modules/eks-node-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.45"
+      version = ">= 4.22"
     }
   }
 }


### PR DESCRIPTION
### Background

```
╷
│ Warning: Argument is deprecated
│
│   with module.node_group.aws_autoscaling_group.this,
│   on .terraform/modules/node_group/modules/eks-node-group/main.tf line 132, in resource "aws_autoscaling_group" "this":
│  132:   tags = local.indirect_managed_asg_tags
│
│ Use tag instead
│
│ (and 3 more similar warnings elsewhere)
```