### PR TITLE
Support default security group for eks-node-group module

### DIFF
--- a/modules/ecr-registry/variables.tf
+++ b/modules/ecr-registry/variables.tf
@@ -11,7 +11,8 @@ variable "replication_policies" {
     allow_create_repository = bool
     repositories            = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "replication_destinations" {
@@ -20,7 +21,8 @@ variable "replication_destinations" {
     registry_id = string
     region      = string
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "pull_through_cache_policies" {
@@ -35,7 +37,8 @@ variable "pull_through_cache_policies" {
     allow_create_repository = bool
     repositories            = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "pull_through_cache_rules" {
@@ -46,22 +49,26 @@ variable "pull_through_cache_rules" {
   EOF
   type        = list(any)
   default     = []
+  nullable    = false
 }
 
 variable "scanning_type" {
   description = "(Optional) The scanning type to set for the registry. Can be either `ENHANCED` or `BASIC`."
   type        = string
   default     = "BASIC"
+  nullable    = false
 }
 
 variable "scanning_on_push_filters" {
   description = "(Optional) A list of repository filter to scan on push. Wildcard character is allowed."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "scanning_continuous_filters" {
   description = "(Optional) A list of repository filter to scan continuous. Wildcard character is allowed."
   type        = list(string)
   default     = []
+  nullable    = false
 }

--- a/modules/ecr-repository/README.md
+++ b/modules/ecr-repository/README.md
@@ -18,11 +18,13 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
@@ -31,7 +33,6 @@ No modules.
 | [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 
 ## Inputs
 

--- a/modules/ecr-repository/migrations.tf
+++ b/modules/ecr-repository/migrations.tf
@@ -1,0 +1,5 @@
+// 2022-10-20
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/ecr-repository/resource-group.tf
+++ b/modules/ecr-repository/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/eks-aws-auth/README.md
+++ b/modules/eks-aws-auth/README.md
@@ -9,14 +9,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.4.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.14.0 |
 
 ## Modules
 

--- a/modules/eks-aws-auth/variables.tf
+++ b/modules/eks-aws-auth/variables.tf
@@ -2,12 +2,14 @@ variable "node_roles" {
   description = "(Optional) A list of ARNs of AWS IAM Roles for EKS node."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "fargate_profile_roles" {
   description = "(Optional) A list of ARNs of AWS IAM Roles for EKS fargate profiles."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "map_roles" {
@@ -17,7 +19,8 @@ variable "map_roles" {
     username = string
     groups   = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "map_users" {
@@ -27,11 +30,13 @@ variable "map_users" {
     username = string
     groups   = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "map_accounts" {
   description = "(Optional) AWS account numbers to automatically map IAM ARNs from."
   type        = list(string)
   default     = []
+  nullable    = false
 }

--- a/modules/eks-aws-auth/versions.tf
+++ b/modules/eks-aws-auth/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     kubernetes = {

--- a/modules/eks-cluster/README.md
+++ b/modules/eks-cluster/README.md
@@ -17,7 +17,7 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1 |
 
@@ -25,13 +25,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 | <a name="module_role__control_plane"></a> [role\_\_control\_plane](#module\_role\_\_control\_plane) | tedilabs/account/aws//modules/iam-role | 0.19.0 |
 | <a name="module_role__fargate_profile"></a> [role\_\_fargate\_profile](#module\_role\_\_fargate\_profile) | tedilabs/account/aws//modules/iam-role | 0.19.0 |
 | <a name="module_role__node"></a> [role\_\_node](#module\_role\_\_node) | tedilabs/account/aws//modules/iam-role | 0.19.0 |
@@ -48,7 +49,6 @@ This module creates following resources.
 | [aws_eks_fargate_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_fargate_profile) | resource |
 | [aws_eks_identity_provider_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_identity_provider_config) | resource |
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pod](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/modules/eks-cluster/migrations.tf
+++ b/modules/eks-cluster/migrations.tf
@@ -1,0 +1,5 @@
+// 2022-10-20
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/eks-cluster/resource-group.tf
+++ b/modules/eks-cluster/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -12,23 +12,27 @@ variable "kubernetes_version" {
   description = "(Optional) Kubernetes version to use for the EKS cluster."
   type        = string
   default     = "1.21"
+  nullable    = false
 }
 
 variable "subnet_ids" {
   description = "(Required) A list of subnets to creates cross-account elastic network interfaces to allow communication between your worker nodes and the Kubernetes control plane. Must be in at least two different availability zones."
   type        = list(string)
+  nullable    = false
 }
 
 variable "service_cidr" {
   description = "(Optional) The CIDR block to assign Kubernetes service IP addresses from. Recommend that you specify a block that does not overlap with resources in other networks that are peered or connected to your VPC. You can only specify a custom CIDR block when you create a cluster, changing this value will force a new cluster to be created. Only valid if `ip_family` is `IPV4`."
   type        = string
   default     = "172.20.0.0/16"
+  nullable    = false
 }
 
 variable "ip_family" {
   description = "(Optional) The IP family used to assign Kubernetes pod and service addresses. Valid values are `IPV4` and `IPV6`. Defaults to `IPV4`. You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created."
   type        = string
   default     = "IPV4"
+  nullable    = false
 
   validation {
     condition     = contains(["IPV4", "IPV6"], var.ip_family)
@@ -40,42 +44,49 @@ variable "endpoint_public_access" {
   description = "(Optional) Indicates whether or not the Amazon EKS public API server endpoint is enabled."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "endpoint_private_access" {
   description = "(Optional) Indicates whether or not the Amazon EKS private API server endpoint is enabled."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "endpoint_public_access_cidrs" {
   description = "(Optional) A list of allowed CIDR to communicate to the Amazon EKS public API server endpoint."
   type        = list(string)
   default     = ["0.0.0.0/0"]
+  nullable    = false
 }
 
 variable "endpoint_private_access_cidrs" {
   description = "(Optional) A list of allowed CIDR to communicate to the Amazon EKS private API server endpoint."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "endpoint_private_access_source_security_group_ids" {
   description = "(Optional) A list of allowed source security group to communicate to the Amazon EKS private API server endpoint."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "log_types" {
   description = "(Optional) A list of the desired control plane logging to enable."
   type        = list(string)
   default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  nullable    = false
 }
 
 variable "log_retention_in_days" {
   description = "(Optional) Number of days to retain log events. Default retention - 90 days. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
   type        = number
   default     = 90
+  nullable    = false
 }
 
 variable "log_encryption_kms_key" {
@@ -88,6 +99,7 @@ variable "encryption_enabled" {
   description = "(Optional) Whether to encrypt kubernetes resources."
   type        = string
   default     = false
+  nullable    = false
 }
 
 variable "encryption_kms_key" {
@@ -100,6 +112,7 @@ variable "encryption_resources" {
   description = "(Optional) List of strings with resources to be encrypted. Valid values: `secrets`."
   type        = list(string)
   default     = ["secrets"]
+  nullable    = false
 }
 
 variable "timeouts" {
@@ -110,12 +123,14 @@ variable "timeouts" {
     update = "60m"
     delete = "15m"
   }
+  nullable = false
 }
 
 variable "fargate_default_subnet_ids" {
   description = "(Optional) A list of defualt subnet IDs for the EKS Fargate Profile. Only used if you do not specified `subnet_ids` in Fargate Profile."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "fargate_profiles" {
@@ -129,6 +144,7 @@ variable "fargate_profiles" {
   EOF
   type        = any
   default     = []
+  nullable    = false
 }
 
 variable "oidc_identity_providers" {
@@ -145,18 +161,21 @@ variable "oidc_identity_providers" {
   EOF
   type        = any
   default     = []
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -168,16 +187,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/eks-cluster/versions.tf
+++ b/modules/eks-cluster/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/eks-irsa/README.md
+++ b/modules/eks-irsa/README.md
@@ -11,26 +11,23 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.45 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.71.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | tedilabs/account/aws//modules/iam-role | 0.19.0 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+No resources.
 
 ## Inputs
 

--- a/modules/eks-irsa/migrations.tf
+++ b/modules/eks-irsa/migrations.tf
@@ -1,0 +1,5 @@
+// 2022-10-20
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/eks-irsa/resource-group.tf
+++ b/modules/eks-irsa/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/eks-irsa/variables.tf
+++ b/modules/eks-irsa/variables.tf
@@ -7,12 +7,14 @@ variable "path" {
   description = "(Optional) Desired path of the IAM role for EKS service accounts."
   type        = string
   default     = "/"
+  nullable    = false
 }
 
 variable "description" {
   description = "(Optional) The description of the role."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "max_session_duration" {
@@ -25,24 +27,28 @@ variable "force_detach_policies" {
   description = "(Optional) Specifies to force detaching any policies the role has before destroying it."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "permissions_boundary" {
   description = "(Optional) The ARN of the policy that is used to set the permissions boundary for the role."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "trusted_iam_entities" {
   description = "(Optional) A list of ARNs of AWS IAM entities who can assume the role."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "trusted_service_accounts" {
   description = "(Optional) A list of Kubernetes service accounts which could be trusted to assume the role. The format should be `<namespace>:<service-account>`. The values can include a multi-character match wildcard (*) or a single-character match wildcard (?) anywhere in the string."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "oidc_provider_urls" {
@@ -57,7 +63,8 @@ variable "trusted_oidc_conditions" {
     condition = string
     values    = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "conditions" {
@@ -67,13 +74,15 @@ variable "conditions" {
     condition = string
     values    = list(string)
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "mfa_required" {
   description = "(Optional) Whether MFA should be required to assume the role."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "mfa_ttl" {
@@ -110,42 +119,49 @@ variable "source_ip_whitelist" {
   description = "(Optional) A list of source IP addresses or CIDRs allowed to assume IAM role from."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "source_ip_blacklist" {
   description = "(Optional) A list of source IP addresses or CIDRs denied to assume IAM role from."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "assumable_roles" {
   description = "(Optional) List of IAM roles ARNs which can be assumed by the role."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "policies" {
   description = "(Optional) List of IAM policies ARNs to attach to IAM role."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "inline_policies" {
   description = "(Optional) Map of inline IAM policies to attach to IAM role. (`name` => `policy`)."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -157,16 +173,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/eks-irsa/versions.tf
+++ b/modules/eks-irsa/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/eks-max-pods/variables.tf
+++ b/modules/eks-max-pods/variables.tf
@@ -7,4 +7,5 @@ variable "use_cni_custom_networking" {
   description = "(Optional) Use EKS CNI Custom Networking."
   type        = bool
   default     = true
+  nullable    = false
 }

--- a/modules/eks-max-pods/versions.tf
+++ b/modules/eks-max-pods/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 }

--- a/modules/eks-node-group/README.md
+++ b/modules/eks-node-group/README.md
@@ -17,13 +17,15 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks_max_pods"></a> [eks\_max\_pods](#module\_eks\_max\_pods) | ../eks-max-pods | n/a |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | tedilabs/network/aws//modules/security-group | ~> 0.26.0 |
 
 ## Resources
 
@@ -31,8 +33,8 @@ This module creates following resources.
 |------|------|
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -46,11 +48,12 @@ This module creates following resources.
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | (Required) The maximum number of instances to run in the EKS cluster node group. | `number` | n/a | yes |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | (Required) The minimum number of instances to run in the EKS cluster node group. | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | (Required) Name of node group to create. | `string` | n/a | yes |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | (Required) All workers will be attached to those security groups. | `list(string)` | n/a | yes |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | (Required) A list of security group IDs to assign to the node group. | `list(string)` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | (Required) A list of subnets to place the EKS cluster node group within. | `list(string)` | n/a | yes |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | (Optional) Associate a public ip address with an instance in a VPC. | `bool` | `false` | no |
 | <a name="input_bootstrap_extra_args"></a> [bootstrap\_extra\_args](#input\_bootstrap\_extra\_args) | (Optional) Extra arguments to add to the `/etc/eks/bootstrap.sh`. | `list(string)` | `[]` | no |
 | <a name="input_cni_custom_networking_enabled"></a> [cni\_custom\_networking\_enabled](#input\_cni\_custom\_networking\_enabled) | (Optional) Whether to use EKS CNI Custom Networking. | `bool` | `false` | no |
+| <a name="input_default_security_group"></a> [default\_security\_group](#input\_default\_security\_group) | (Optional) The configuration of the default security group for the EKS node gorup. `default_security_group` block as defined below.<br>    (Optional) `enabled` - Whether to use the default security group. Defaults to `true`.<br>    (Optional) `name` - The name of the default security group. If not provided, the node group name is used for the name of security group.<br>    (Optional) `description` - The description of the default security group.<br>    (Optional) `ingress_rules` - A list of ingress rules in a security group.<br>    (Optional) `egress_rules` - A list of egress rules in a security group. | <pre>object({<br>    enabled       = optional(bool, true)<br>    name          = optional(string, null)<br>    description   = optional(string, "Managed by Terraform.")<br>    ingress_rules = optional(any, [])<br>    egress_rules  = optional(any, [])<br>  })</pre> | `{}` | no |
 | <a name="input_desired_size"></a> [desired\_size](#input\_desired\_size) | (Optional) The number of instances that should be running in the group. | `number` | `null` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | (Optional) If true, the launched EC2 instance will be EBS-optimized. | `bool` | `false` | no |
 | <a name="input_enabled_metrics"></a> [enabled\_metrics](#input\_enabled\_metrics) | (Optional) A list of metrics to collect. The allowed values are GroupDesiredCapacity, GroupInServiceCapacity, GroupPendingCapacity, GroupMinSize, GroupMaxSize, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupStandbyCapacity, GroupTerminatingCapacity, GroupTerminatingInstances, GroupTotalCapacity, GroupTotalInstances. | `list(string)` | <pre>[<br>  "GroupMinSize",<br>  "GroupMaxSize",<br>  "GroupDesiredCapacity",<br>  "GroupInServiceCapacity",<br>  "GroupInServiceInstances",<br>  "GroupPendingCapacity",<br>  "GroupPendingInstances",<br>  "GroupStandbyCapacity",<br>  "GroupStandbyInstances",<br>  "GroupTerminatingCapacity",<br>  "GroupTerminatingInstances",<br>  "GroupTotalCapacity",<br>  "GroupTotalInstances"<br>]</pre> | no |
@@ -87,4 +90,5 @@ This module creates following resources.
 | <a name="output_max_size"></a> [max\_size](#output\_max\_size) | The maximum number of instances in the EKS cluster node group. |
 | <a name="output_min_size"></a> [min\_size](#output\_min\_size) | The minimum number of instances in the EKS cluster node group. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the node group. |
+| <a name="output_network"></a> [network](#output\_network) | The configuration for network of the EKS node group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/eks-node-group/main.tf
+++ b/modules/eks-node-group/main.tf
@@ -67,8 +67,11 @@ resource "aws_launch_template" "this" {
   }
 
   network_interfaces {
-    description     = "Managed by Terraform."
-    security_groups = var.security_group_ids
+    description = "Managed by Terraform."
+    security_groups = (var.default_security_group.enabled
+      ? concat(module.security_group.*.id, var.security_groups)
+      : var.security_groups
+    )
 
     associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true

--- a/modules/eks-node-group/migrations.tf
+++ b/modules/eks-node-group/migrations.tf
@@ -1,0 +1,5 @@
+// 2022-10-20
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/eks-node-group/outputs.tf
+++ b/modules/eks-node-group/outputs.tf
@@ -38,6 +38,16 @@ output "instance_profile" {
   value       = var.instance_profile
 }
 
+output "network" {
+  description = <<EOF
+  The configuration for network of the EKS node group.
+  EOF
+  value = {
+    default_security_group = one(module.security_group.*.id)
+    security_groups        = aws_launch_template.this.network_interfaces[0].security_groups
+  }
+}
+
 
 ###################################################
 # EKS

--- a/modules/eks-node-group/resource-group.tf
+++ b/modules/eks-node-group/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/eks-node-group/security-group.tf
+++ b/modules/eks-node-group/security-group.tf
@@ -1,0 +1,44 @@
+data "aws_subnet" "this" {
+  id = var.subnet_ids[0]
+}
+
+locals {
+  vpc_id = data.aws_subnet.this.vpc_id
+}
+
+
+###################################################
+# Security Group
+###################################################
+
+module "security_group" {
+  source  = "tedilabs/network/aws//modules/security-group"
+  version = "~> 0.26.0"
+
+  count = var.default_security_group.enabled ? 1 : 0
+
+  name        = coalesce(var.default_security_group.name, local.metadata.name)
+  description = var.default_security_group.description
+  vpc_id      = local.vpc_id
+
+  ingress_rules = [
+    for i, rule in var.default_security_group.ingress_rules :
+    merge(rule, {
+      id = try(rule.id, "eks-node-group-${i}")
+    })
+  ]
+  egress_rules = [
+    for i, rule in var.default_security_group.egress_rules :
+    merge(rule, {
+      id = try(rule.id, "eks-node-group-${i}")
+    })
+  ]
+
+  resource_group_enabled = false
+  module_tags_enabled    = false
+
+  tags = merge(
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/eks-node-group/variables.tf
+++ b/modules/eks-node-group/variables.tf
@@ -38,12 +38,14 @@ variable "target_group_arns" {
   description = "(Optional) A set of `aws_alb_target_group` ARNs, for use with Application or Network Load Balancing."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "force_delete" {
   description = "(Optional) Allows deleting the autoscaling group without waiting for all instances in the pool to terminate."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "enabled_metrics" {
@@ -64,6 +66,7 @@ variable "enabled_metrics" {
     "GroupTotalCapacity",
     "GroupTotalInstances",
   ]
+  nullable = false
 }
 
 
@@ -74,33 +77,39 @@ variable "enabled_metrics" {
 variable "instance_ami" {
   description = "(Required) The AMI to run on each instance in the EKS cluster node group."
   type        = string
+  nullable    = false
 }
 
 variable "instance_type" {
   description = "(Required) The type of instances to run in the EKS cluster node group."
   type        = string
+  nullable    = false
 }
 
 variable "instance_ssh_key" {
   description = "(Required) The name of the SSH Key that should be used to access the each nodes."
   type        = string
+  nullable    = false
 }
 
 variable "instance_profile" {
   description = "(Required) The name attribute of the IAM instance profile to associate with launched instances."
   type        = string
+  nullable    = false
 }
 
 variable "root_volume_type" {
   description = "(Optional) The volume type for root volume. Can be standard, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1`."
   type        = string
   default     = "gp2"
+  nullable    = false
 }
 
 variable "root_volume_size" {
   description = "(Optional) The size of the root volume in gigabytes."
   type        = number
   default     = 20
+  nullable    = false
 }
 
 variable "root_volume_iops" {
@@ -119,6 +128,7 @@ variable "root_volume_encryption_enabled" {
   description = "(Optional) Enables EBS encryption on the root volume."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "root_volume_encryption_kms_key_id" {
@@ -131,65 +141,96 @@ variable "ebs_optimized" {
   description = "(Optional) If true, the launched EC2 instance will be EBS-optimized."
   type        = bool
   default     = false
+  nullable    = false
 }
 
-variable "security_group_ids" {
-  description = "(Required) All workers will be attached to those security groups."
+variable "default_security_group" {
+  description = <<EOF
+  (Optional) The configuration of the default security group for the EKS node gorup. `default_security_group` block as defined below.
+    (Optional) `enabled` - Whether to use the default security group. Defaults to `true`.
+    (Optional) `name` - The name of the default security group. If not provided, the node group name is used for the name of security group.
+    (Optional) `description` - The description of the default security group.
+    (Optional) `ingress_rules` - A list of ingress rules in a security group.
+    (Optional) `egress_rules` - A list of egress rules in a security group.
+  EOF
+  type = object({
+    enabled       = optional(bool, true)
+    name          = optional(string, null)
+    description   = optional(string, "Managed by Terraform.")
+    ingress_rules = optional(any, [])
+    egress_rules  = optional(any, [])
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "security_groups" {
+  description = "(Required) A list of security group IDs to assign to the node group."
   type        = list(string)
+  nullable    = false
 }
 
 variable "associate_public_ip_address" {
   description = "(Optional) Associate a public ip address with an instance in a VPC."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "monitoring_enabled" {
   description = "(Optional) If true, the launched EC2 instance will have detailed monitoring enabled."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "node_labels" {
   description = "(Optional) A map of labels to add to the EKS cluster node group."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "node_taints" {
   description = "(Optional) A list of taints to add to the EKS cluster node group."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "bootstrap_extra_args" {
   description = "(Optional) Extra arguments to add to the `/etc/eks/bootstrap.sh`."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "kubelet_extra_args" {
   description = "(Optional) Extra arguments to add to the kubelet. Useful for adding labels or taints."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "cni_custom_networking_enabled" {
   description = "(Optional) Whether to use EKS CNI Custom Networking."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -201,16 +242,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }


### PR DESCRIPTION
### Background

- Support default security group for `eks-node-group` module
- **Break Change**: change `var.security_group_ids` to `var.security_groups` in `eks-node-group` module.


### Misc

- Bump terraform version to the minimum `v1.2`.