### PR TITLE
feat: add permissions_boundary support for IAM roles

### DIFF
--- a/modules/ecr-registry/iam.tf
+++ b/modules/ecr-registry/iam.tf
@@ -29,6 +29,8 @@ module "role__pull_through_cache" {
     var.default_pull_through_cache_role.inline_policies
   )
 
+  permissions_boundary = var.default_pull_through_cache_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false

--- a/modules/ecr-registry/variables.tf
+++ b/modules/ecr-registry/variables.tf
@@ -112,6 +112,7 @@ variable "default_pull_through_cache_role" {
     (Optional) `description` - The description of the default IAM role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default IAM role. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default IAM role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default IAM role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -119,8 +120,9 @@ variable "default_pull_through_cache_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false

--- a/modules/eks-cluster/iam.tf
+++ b/modules/eks-cluster/iam.tf
@@ -27,6 +27,8 @@ module "role" {
   )
   inline_policies = var.default_cluster_role.inline_policies
 
+  permissions_boundary = var.default_cluster_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false
@@ -71,6 +73,8 @@ module "role__node" {
     var.default_node_role.policies,
   )
   inline_policies = var.default_node_role.inline_policies
+
+  permissions_boundary = var.default_node_role.permissions_boundary
 
   instance_profile = {
     enabled = true

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -264,6 +264,7 @@ variable "default_cluster_role" {
     (Optional) `description` - The description of the default cluster role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default cluster role. `AmazonEKSClusterPolicy` is always attached. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default cluster role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default cluster role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -271,8 +272,9 @@ variable "default_cluster_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false
@@ -287,6 +289,7 @@ variable "default_node_role" {
     (Optional) `description` - The description of the default node role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default node role. `AmazonEKSWorkerNodePolicy`, `AmazonEC2ContainerRegistryReadOnly` are always attached. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default node role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default node role.
   EOF
   type = object({
     enabled     = optional(bool, false)
@@ -294,8 +297,9 @@ variable "default_node_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false

--- a/modules/eks-fargate-profile/iam.tf
+++ b/modules/eks-fargate-profile/iam.tf
@@ -27,6 +27,8 @@ module "role" {
   )
   inline_policies = var.default_pod_execution_role.inline_policies
 
+  permissions_boundary = var.default_pod_execution_role.permissions_boundary
+
   force_detach_policies = true
   resource_group = {
     enabled = false

--- a/modules/eks-fargate-profile/variables.tf
+++ b/modules/eks-fargate-profile/variables.tf
@@ -32,6 +32,7 @@ variable "default_pod_execution_role" {
     (Optional) `description` - The description of the default pod execution role.
     (Optional) `policies` - A list of IAM policy ARNs to attach to the default pod execution role. `AmazonEKSFargatePodExecutionRolePolicy` is always attached. Defaults to `[]`.
     (Optional) `inline_policies` - A Map of inline IAM policies to attach to the default pod execution role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default pod execution role.
   EOF
   type = object({
     enabled     = optional(bool, true)
@@ -39,8 +40,9 @@ variable "default_pod_execution_role" {
     path        = optional(string, "/")
     description = optional(string, "Managed by Terraform.")
 
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
## Summary

This PR adds support for IAM permissions boundary to all modules that use the `iam-role` module from `terraform-aws-account`.

## Changes

### eks-cluster
- Added `permissions_boundary` parameter to `default_cluster_role` variable
- Added `permissions_boundary` parameter to `default_node_role` variable
- Updated `iam.tf` to pass `permissions_boundary` to both IAM role modules

### eks-fargate-profile
- Added `permissions_boundary` parameter to `default_pod_execution_role` variable
- Updated `iam.tf` to pass `permissions_boundary` to the IAM role module

### ecr-registry
- Added `permissions_boundary` parameter to `default_pull_through_cache_role` variable
- Updated `iam.tf` to pass `permissions_boundary` to the IAM role module

## Reference

This change follows the same pattern as implemented in:
https://github.com/tedilabs/terraform-aws-security/commit/a65368004de7769c5bc281d255293c1c734743ed

## Test plan

- [ ] Review variable definitions
- [ ] Verify parameter is correctly passed to iam-role module
- [ ] Run terraform validate on affected modules
- [ ] Run pre-commit hooks