### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/ecr-registry-enhanced-scanning/main.tf
+++ b/examples/ecr-registry-enhanced-scanning/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "registry" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   scanning_type               = "ENHANCED"
   scanning_on_push_filters    = ["quay/*", "sre/*"]

--- a/examples/ecr-registry-full/main.tf
+++ b/examples/ecr-registry-full/main.tf
@@ -12,7 +12,7 @@ data "aws_caller_identity" "this" {}
 module "registry" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   ## Replication
   replication_destinations = []

--- a/examples/ecr-registry-pull-through-cache/main.tf
+++ b/examples/ecr-registry-pull-through-cache/main.tf
@@ -12,7 +12,7 @@ data "aws_caller_identity" "this" {}
 module "registry" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   pull_through_cache_policies = [
     {

--- a/examples/ecr-registry-replication/main.tf
+++ b/examples/ecr-registry-replication/main.tf
@@ -20,7 +20,7 @@ data "aws_caller_identity" "dst" {
 module "registry_src" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   replication_destinations = [
     {
@@ -33,7 +33,7 @@ module "registry_src" {
 module "registry_dst" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   providers = {
     aws = aws.dst

--- a/examples/ecr-registry-simple/main.tf
+++ b/examples/ecr-registry-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "registry" {
   source = "../../modules/ecr-registry"
   # source  = "tedilabs/container/aws//modules/ecr-registry"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   scanning_type = "BASIC"
 }

--- a/examples/ecr-repository-encryption-kms/main.tf
+++ b/examples/ecr-repository-encryption-kms/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "repository" {
   source = "../../modules/ecr-repository"
   # source  = "tedilabs/container/aws//modules/ecr-repository"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   name = "examples/simple"
 

--- a/examples/ecr-repository-full/main.tf
+++ b/examples/ecr-repository-full/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "ecr_repository_policy" {
 module "repository" {
   source = "../../modules/ecr-repository"
   # source  = "tedilabs/container/aws//modules/ecr-repository"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   name = "examples/simple"
 

--- a/examples/ecr-repository-lifecycle-rules/main.tf
+++ b/examples/ecr-repository-lifecycle-rules/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "repository" {
   source = "../../modules/ecr-repository"
   # source  = "tedilabs/container/aws//modules/ecr-repository"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   name = "examples/simple"
 

--- a/examples/ecr-repository-simple/main.tf
+++ b/examples/ecr-repository-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "repository" {
   source = "../../modules/ecr-repository"
   # source  = "tedilabs/container/aws//modules/ecr-repository"
-  # version = "~> 0.20.0"
+  # version = "~> 0.27.0"
 
   name = "examples/simple"
 

--- a/modules/eks-cluster/security-groups.tf
+++ b/modules/eks-cluster/security-groups.tf
@@ -83,7 +83,7 @@ resource "aws_vpc_security_group_ingress_rule" "pod" {
 
 module "security_group__control_plane" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.1.0"
+  version = "~> 1.2.0"
 
   region = var.region
 
@@ -179,7 +179,7 @@ module "security_group__control_plane" {
 
 module "security_group__node" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.1.0"
+  version = "~> 1.2.0"
 
   region = var.region
 
@@ -287,7 +287,7 @@ module "security_group__node" {
 
 module "security_group__pod" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.1.0"
+  version = "~> 1.2.0"
 
   region = var.region
 

--- a/modules/eks-node-group/security-group.tf
+++ b/modules/eks-node-group/security-group.tf
@@ -17,7 +17,7 @@ locals {
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 


### PR DESCRIPTION
## What & why

The `version` constraints on our sibling `tedilabs` child modules had drifted several minor releases behind their latest published versions. This realigns them to the house convention of pinning the **minor floor** (`~> MAJOR.MINOR.0`) rather than an exact patch, so patch releases are picked up automatically.

Two groups are touched: the live `tedilabs/network/aws//modules/security-group` calls in `modules/eks-cluster` and `modules/eks-node-group`, and the commented-out registry alternatives in `examples/` that document how to consume this repo's own modules from the registry. No behavioural change is expected — see the interface analysis below.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `modules/eks-cluster/security-groups.tf:86` (`security_group__control_plane`) | `~> 1.1.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/security-group` | `modules/eks-cluster/security-groups.tf:182` (`security_group__node`) | `~> 1.1.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/security-group` | `modules/eks-cluster/security-groups.tf:290` (`security_group__pod`) | `~> 1.1.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/security-group` | `modules/eks-node-group/security-group.tf:20` (`security_group`) | `~> 1.0.0` | `~> 1.2.0` | `v1.2.3` |

### Example docs (commented)

These are commented `# version` lines inside `examples/`; the active `source` in those examples is the local path `../../modules/x`, so these lines are documentation only and have no effect on `terraform` behaviour. They are **self**-references to this repo's own modules.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-enhanced-scanning/main.tf:13` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-full/main.tf:15` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-pull-through-cache/main.tf:15` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-replication/main.tf:23` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-replication/main.tf:36` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-registry` | `examples/ecr-registry-simple/main.tf:13` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-repository` | `examples/ecr-repository-encryption-kms/main.tf:13` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-repository` | `examples/ecr-repository-full/main.tf:41` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-repository` | `examples/ecr-repository-lifecycle-rules/main.tf:13` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |
| `tedilabs/container/aws//modules/ecr-repository` | `examples/ecr-repository-simple/main.tf:13` | `~> 0.20.0` | `~> 0.27.0` | `v0.27.4` |

## Interface changes between the old and new versions

### `tedilabs/network/aws//modules/security-group`: `v1.1.1` -> `v1.2.3` (eks-cluster)

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.1.1...v1.2.3

**Verdict: BACKWARD_COMPATIBLE. No calling code changed.**

- **Added variables:** none.
- **Removed variables:** none.
- **Renamed/retyped variables:** exactly one change, applied inside both the `ingress_rules` and `egress_rules` element objects — `from_port` and `to_port` went from required `number` to `optional(number)`. This is a pure *relaxation*: every value shape that was valid before is still valid, so all existing call sites remain correct as written. The three `eks-cluster` security groups all pass explicit `from_port`/`to_port` values and continue to work unchanged.
- **Output changes:** none. `outputs.tf` is byte-identical between the two tags.
- **Provider / Terraform version floor:** unchanged. Both tags already declare `required_version = ">= 1.12"` and `hashicorp/aws >= 6.12`, so this repo's own constraints need no adjustment.

Apart from `variables.tf`, the only other file that differs is the generated `README.md`.

### `tedilabs/network/aws//modules/security-group`: `v1.0.2` -> `v1.2.3` (eks-node-group)

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.0.2...v1.2.3

**Verdict: BACKWARD_COMPATIBLE. No calling code changed.**

`variables.tf` at `v1.0.2` and `v1.1.1` are identical blobs, so the variable-level story is exactly the same as above: the only interface change is `from_port` / `to_port` relaxing to `optional(number)` in the rule element objects. No variables added or removed, no output changes, and no version floor change (`>= 1.12` / `aws >= 6.12` at both tags).

**Operational note — not applicable to this repo.** Between `v1.0.2` and `v1.2.3` the module's internal RAM share changed shape: `resources` went from a list to a map keyed by `var.name`, the nested `tedilabs/organization/aws//modules/ram-share` dependency moved `~> 0.4.0` -> `~> 0.5.0`, and the share name is now sanitised through `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. That would matter for a caller that passes `shares` together with a `name` containing characters outside `[a-zA-Z0-9_.-]`, because the generated RAM share name would change. **This repo passes `shares` at none of its four security-group call sites** (verified by grep), and `shares` defaults to `[]`, so `module.share` has no instances and this cannot produce any plan churn here. Recorded only so reviewers do not have to re-derive it.

## Verification

- `terraform fmt -recursive -check .` — **passes** (no reformatting needed).
- `modules/eks-cluster`: `terraform init -backend=false -upgrade` + `terraform validate` — **Success! The configuration is valid.** `.terraform/modules/modules.json` confirms `security-group` resolved to **1.2.3** under the new constraint (nested: `misc/aws//modules/resource-group` 0.12.0, `organization/aws//modules/ram-share` 0.5.6).
- `modules/eks-node-group`: `terraform init -backend=false -upgrade` + `terraform validate` — **Success! The configuration is valid.** `security-group` likewise resolved to **1.2.3**.
- All `.terraform` directories and lock files created during verification were removed before committing; `git status --porcelain` shows only the eleven intended `.tf` files.
- No `terraform plan` or `apply` was run, so no AWS credentials were used and no live state was consulted. The claim of an empty plan is inferred from the interface diff, not observed.

### Pre-existing breakage in `examples/` (NOT introduced by this PR, NOT fixed here)

Every one of the nine `examples/` directories touched by this PR fails `terraform init` / `terraform validate`, and **all nine fail identically on an unmodified `origin/main` checkout**. I verified this explicitly in a separate pristine detached worktree at `origin/main` before concluding it was pre-existing. This PR only edits commented-out `# version` lines in those files, which Terraform does not parse, so it cannot be the cause.

Two independent failure classes, both stemming from `examples/` having drifted behind the local `modules/ecr-*` interface they call via `../../modules/x`:

1. **Stale module arguments** — `scanning_on_push_filters` / `scanning_continuous_filters` (`ecr-registry-enhanced-scanning`, `ecr-registry-full`), `replication_destinations` (`ecr-registry-replication`), `encryption_type` / `encryption_kms_key` / `repository_policy` (`ecr-repository-encryption-kms`, `ecr-repository-full`), and a now-required `image_tag_mutability` that is not supplied (`ecr-repository-lifecycle-rules`, `ecr-repository-simple`).
2. **Stale provider constraint** — `ecr-registry-simple` and `ecr-registry-pull-through-cache` pin `hashicorp/aws ~> 4.0` in their own `versions.tf` while the local modules now require `>= 6.32.0`, so provider resolution fails outright.

Fixing these means rewriting the ECR examples against the current module interface across nine directories, which is a substantive refactor well outside the scope of a version-constraint alignment. Flagging it here so it can be tracked separately; happy to open a follow-up issue.

## Supersedes

- #76 — `chore(deps): update tedilabs/network/aws requirement from ~> 1.1.0 to ~> 1.2.2 in /modules/eks-cluster`
- #77 — `chore(deps): update tedilabs/network/aws requirement from ~> 1.0.0 to ~> 1.2.2 in /modules/eks-node-group`

This PR supersedes both because dependabot pins the exact patch release (`~> 1.2.2`) instead of the house minor-floor convention (`~> 1.2.0`), and because it does not cover the commented registry references in `examples/`. Both dependabot PRs are left open for the maintainer to close.
