### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/ecr-registry-enhanced-scanning/versions.tf
+++ b/examples/ecr-registry-enhanced-scanning/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-registry-full/versions.tf
+++ b/examples/ecr-registry-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-registry-pull-through-cache/versions.tf
+++ b/examples/ecr-registry-pull-through-cache/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-registry-replication/versions.tf
+++ b/examples/ecr-registry-replication/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-registry-simple/versions.tf
+++ b/examples/ecr-registry-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-repository-encryption-kms/versions.tf
+++ b/examples/ecr-repository-encryption-kms/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-repository-full/versions.tf
+++ b/examples/ecr-repository-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-repository-lifecycle-rules/versions.tf
+++ b/examples/ecr-repository-lifecycle-rules/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ecr-repository-simple/versions.tf
+++ b/examples/ecr-repository-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

All 9 example roots in `examples/` pin `hashicorp/aws` to `~> 4.0` (i.e. `< 5.0.0`), but the local
modules they instantiate require a much newer provider — `modules/ecr-repository` declares
`>= 6.12` and `modules/ecr-registry` declares `>= 6.32`. Terraform intersects every constraint in
the graph, so the intersection is empty and `terraform init` hard-fails. The examples are
unusable as written.

Verbatim, from `examples/ecr-registry-simple` on `main`:

```
Initializing provider plugins found in the configuration...
- Finding hashicorp/aws versions matching "~> 4.0, >= 6.0.0, >= 6.12.0, >= 6.32.0"...

Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 4.0, >= 6.0.0, >=
6.12.0, >= 6.32.0
```

The `required_version = "~> 1.5"` pins were also off-convention and are corrected in the same pass.

This PR touches **only** `examples/*/versions.tf`. No module code, no docs, no other `*.tf`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `~> 6.0`

`~> 6.0` is sufficient even though the modules declare `>= 6.12` / `>= 6.32`: Terraform intersects
all constraints in the graph, so `~> 6.0` ∩ `>= 6.32` = `[6.32, 7.0)`. Confirmed empirically below —
both resolutions selected **v6.58.0**. The module floors are therefore deliberately *not* copied
into the roots.

## Changed roots

All 9 roots are init-breaking conflicts; none were style-only.

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/ecr-registry-enhanced-scanning` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-registry` needs `>= 6.32`) |
| `examples/ecr-registry-full` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-registry` needs `>= 6.32`) |
| `examples/ecr-registry-pull-through-cache` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-registry` needs `>= 6.32`) |
| `examples/ecr-registry-replication` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-registry` needs `>= 6.32`) |
| `examples/ecr-registry-simple` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-registry` needs `>= 6.32`) |
| `examples/ecr-repository-encryption-kms` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-repository` needs `>= 6.12`) |
| `examples/ecr-repository-full` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-repository` needs `>= 6.12`) |
| `examples/ecr-repository-lifecycle-rules` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-repository` needs `>= 6.12`) |
| `examples/ecr-repository-simple` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/ecr-repository` needs `>= 6.12`) |

## Verification

`terraform fmt -recursive -check .` — **passes**.

Per root, `terraform init -backend=false` then `terraform validate`, run serially with a private
`TF_PLUGIN_CACHE_DIR`:

| Example root | Result |
| --- | --- |
| `examples/ecr-registry-pull-through-cache` | `init OK, validate OK` |
| `examples/ecr-registry-simple` | `init OK, validate OK` |
| `examples/ecr-registry-enhanced-scanning` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-registry-full` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-registry-replication` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-repository-encryption-kms` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-repository-full` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-repository-lifecycle-rules` | `init FAILS — pre-existing stale module arguments, see below` |
| `examples/ecr-repository-simple` | `init FAILS — pre-existing stale module arguments, see below` |

The two roots that reach provider installation prove the constraint resolution works:

```
- Finding hashicorp/aws versions matching ">= 6.0.0, ~> 6.0, >= 6.12.0, >= 6.32.0"...
- Installing hashicorp/aws v6.58.0...
- Installed hashicorp/aws v6.58.0 (signed by HashiCorp)
Terraform has been successfully initialized!
```

**Important nuance about the other 7 roots.** In these examples the stale-argument errors are
raised during `init`'s *module load* phase, which runs **before** provider installation. So those
roots now abort earlier than provider resolution and the fix cannot be observed directly in their
`init` output — but note that **the `no available releases match the given constraints` error is
gone from all of them**. To confirm resolution independently for the `modules/ecr-repository` floor
(the one not covered by the two passing roots), a throwaway root with the new `versions.tf` and a
minimal, argument-correct call to `../../modules/ecr-repository` was initialised and discarded (it
is not part of this PR):

```
- Finding hashicorp/aws versions matching ">= 6.0.0, ~> 6.0, >= 6.12.0"...
- Installed hashicorp/aws v6.58.0 (signed by HashiCorp)
Terraform has been successfully initialized!
```

Both provider floors present in this repo therefore resolve cleanly under `~> 6.0`.

## Pre-existing failures newly exposed

Until now every one of these roots died at provider resolution, so their HCL was never checked.
With `init` able to get past the constraint error, 7 roots surface **pre-existing** bugs: their
`module` blocks pass arguments that `modules/ecr-repository` / `modules/ecr-registry` no longer
accept, and omit a now-required one.

**These are deliberately NOT fixed in this PR** — they are a separate, larger piece of work that
has not been approved. **CI will stay red for these 7 roots after this PR merges**, and this PR
does not claim to make them green. Its scope is strictly making the provider constraint resolvable.

Exact errors, per root:

- `examples/ecr-registry-enhanced-scanning`
  - `Unsupported argument` — `main.tf` line 16: `scanning_on_push_filters = ["quay/*", "sre/*"]` — `An argument named "scanning_on_push_filters" is not expected here.`
  - `Unsupported argument` — `main.tf` line 17: `scanning_continuous_filters = ["example/example"]` — `An argument named "scanning_continuous_filters" is not expected here.`
- `examples/ecr-registry-full`
  - `Unsupported argument` — `main.tf` line 18: `replication_destinations = []` — `An argument named "replication_destinations" is not expected here.`
  - `Unsupported argument` — `main.tf` line 54: `scanning_on_push_filters = ["quay/*", "sre/*"]` — `An argument named "scanning_on_push_filters" is not expected here.`
  - `Unsupported argument` — `main.tf` line 55: `scanning_continuous_filters = ["example/example"]` — `An argument named "scanning_continuous_filters" is not expected here.`
- `examples/ecr-registry-replication`
  - `Unsupported argument` — `main.tf` line 25, in module `registry_src`: `replication_destinations = [` — `An argument named "replication_destinations" is not expected here.`
- `examples/ecr-repository-encryption-kms`
  - `Missing required argument` — `main.tf` line 10, in module `repository`: `The argument "image_tag_mutability" is required, but no definition was found.`
  - `Unsupported argument` — `main.tf` line 18: `encryption_type = "KMS"` — `An argument named "encryption_type" is not expected here.`
  - `Unsupported argument` — `main.tf` line 19: `encryption_kms_key = null` — `An argument named "encryption_kms_key" is not expected here.`
- `examples/ecr-repository-full`
  - `Missing required argument` — `main.tf` line 38, in module `repository`: `The argument "image_tag_mutability" is required, but no definition was found.`
  - `Unsupported argument` — `main.tf` line 46: `image_tag_immutable_enabled = true` — `An argument named "image_tag_immutable_enabled" is not expected here.`
  - `Unsupported argument` — `main.tf` line 49: `encryption_type = "KMS"` — `An argument named "encryption_type" is not expected here.`
  - `Unsupported argument` — `main.tf` line 50: `encryption_kms_key = null` — `An argument named "encryption_kms_key" is not expected here.`
  - `Unsupported argument` — `main.tf` line 52: `repository_policy = data.aws_iam_policy_document.ecr_repository_policy.json` — `An argument named "repository_policy" is not expected here.`
- `examples/ecr-repository-lifecycle-rules`
  - `Missing required argument` — `main.tf` line 10, in module `repository`: `The argument "image_tag_mutability" is required, but no definition was found.`
- `examples/ecr-repository-simple`
  - `Missing required argument` — `main.tf` line 10, in module `repository`: `The argument "image_tag_mutability" is required, but no definition was found.`

## Related PRs

Open PRs in this repo at the time of writing are all dependabot bumps, with file sets disjoint from
this one:

- #77 `chore(deps): update tedilabs/network/aws requirement ... in /modules/eks-node-group` — touches `modules/**`
- #76 `chore(deps): update tedilabs/network/aws requirement ... in /modules/eks-cluster` — touches `modules/**`
- #70 `chore(deps): bump actions/checkout from 4 to 6` — touches `.github/**`
- #69 `chore(deps): bump tj-actions/changed-files from 44 to 47` — touches `.github/**`

None of them touch `examples/*/versions.tf`, so there is no overlap or merge-order dependency.
